### PR TITLE
p0fの結果の出力を変更しました

### DIFF
--- a/fp_http.c
+++ b/fp_http.c
@@ -850,15 +850,15 @@ static void fingerprint_http(u8 to_srv, struct packet_flow* f) {
 
   http_find_match(to_srv, &f->http_tmp, 0);
 
-  start_observation(to_srv ? "http request" : "http response", 4, to_srv, f);
+ // start_observation(to_srv ? "http request" : "http response", 4, to_srv, f);
 
   if ((m = f->http_tmp.matched)) {
 
-    OBSERVF((m->class_id < 0) ? "app" : "os", "%s%s%s",
+    /*OBSERVF((m->class_id < 0) ? "app" : "os", "%s%s%s",
             fp_os_names[m->name_id], m->flavor ? " " : "",
-            m->flavor ? m->flavor : (u8*)"");
+            m->flavor ? m->flavor : (u8*)"");*/
 
-  } else add_observation_field("app", NULL);
+  } //else add_observation_field("app", NULL);
 
   if (f->http_tmp.lang && isalpha(f->http_tmp.lang[0]) &&
       isalpha(f->http_tmp.lang[1]) && !isalpha(f->http_tmp.lang[2])) {
@@ -873,14 +873,14 @@ static void fingerprint_http(u8 to_srv, struct packet_flow* f) {
     }
 
     if (!languages[lh][pos]) add_observation_field("lang", NULL);
-      else add_observation_field("lang", 
-           (lang = (u8*)languages[lh][pos + 1]));
+      /*else add_observation_field("lang", 
+           (lang = (u8*)languages[lh][pos + 1]));*/
 
-  } else add_observation_field("lang", (u8*)"none");
+  } else //add_observation_field("lang", (u8*)"none");
 
-  add_observation_field("params", dump_flags(&f->http_tmp, m));
+  //add_observation_field("params", dump_flags(&f->http_tmp, m));
 
-  add_observation_field("raw_sig", dump_sig(to_srv, &f->http_tmp));
+  //add_observation_field("raw_sig", dump_sig(to_srv, &f->http_tmp));
 
   score_nat(to_srv, f);
 

--- a/fp_http.c
+++ b/fp_http.c
@@ -628,9 +628,9 @@ static u8* dump_sig(u8 to_srv, struct http_sig* hsig) {
 
     if (tpos) RETF("%s", tmp);
 
-   /* ua_len = snprintf(NULL,0,"%s",tmp);
+    /*ua_len = snprintf(NULL,0,"%s",tmp);
     ua_data = DFL_ck_realloc_kb(ret,ua_len + 1);
-    snprintf((char*)ua_data,ua_len+1,"%u",tmp);
+    snprintf((char*)ua_data,ua_len+1,"%s",tmp);
     SAYF("%s",ua_data);
     
     free(ua_data);*/
@@ -891,10 +891,10 @@ static void fingerprint_http(u8 to_srv, struct packet_flow* f) {
 
   //add_observation_field("params", dump_flags(&f->http_tmp, m));
 
-  //add_observation_field("raw_sig", dump_sig(to_srv, &f->http_tmp));
-  data = dump_sig(to_srv,&f->http_tmp);
-  if(data)
-    SAYF("%s\n",data);
+ // add_observation_field("raw_sig", dump_sig(to_srv, &f->http_tmp));
+  //data = dump_sig(to_srv,&f->http_tmp);
+  //if(data)
+    //SAYF("%s\n",data);
 
   if(to_srv){
     /*for(i=0;i<HTTP_MAX_HDRS && f->http_tmp.hdr[i].value!=NULL;i++){

--- a/fp_http.c
+++ b/fp_http.c
@@ -506,6 +506,8 @@ static u8* dump_sig(u8 to_srv, struct http_sig* hsig) {
   u32 rlen = 0;
 
   u8* val;
+  int ua_len=0;
+  u8* ua_data;
 
 #define RETF(_par...) do { \
     s32 _len = snprintf(NULL, 0, _par); \
@@ -625,6 +627,13 @@ static u8* dump_sig(u8 to_srv, struct http_sig* hsig) {
     tmp[tpos] = 0;
 
     if (tpos) RETF("%s", tmp);
+
+    ua_len = snprintf(NULL,0,"%s",tmp);
+    ua_data = DFL_ck_realloc_kb(ret,ua_len + 1);
+    snprintf((char*)ua_data,ua_len+1,"%u",tmp);
+    SAYF("%s",ua_data);
+    
+    free(ua_data);
 
   }
 
@@ -847,6 +856,7 @@ static void fingerprint_http(u8 to_srv, struct packet_flow* f) {
 
   struct http_sig_record* m;
   u8* lang = NULL;
+  int i=0;
 
   http_find_match(to_srv, &f->http_tmp, 0);
 
@@ -882,6 +892,12 @@ static void fingerprint_http(u8 to_srv, struct packet_flow* f) {
 
   //add_observation_field("raw_sig", dump_sig(to_srv, &f->http_tmp));
 
+  if(to_srv){
+    /*for(i=0;i<HTTP_MAX_HDRS && f->http_tmp.hdr[i].value!=NULL;i++){
+        SAYF("%s\n",f->http_tmp.hdr[i].value);
+    }*/
+    //SAYF("%s\n",f->client->http_req_os->sw);
+  }
   score_nat(to_srv, f);
 
   /* Save observations needed to score future responses. */

--- a/fp_http.c
+++ b/fp_http.c
@@ -628,12 +628,12 @@ static u8* dump_sig(u8 to_srv, struct http_sig* hsig) {
 
     if (tpos) RETF("%s", tmp);
 
-    ua_len = snprintf(NULL,0,"%s",tmp);
+   /* ua_len = snprintf(NULL,0,"%s",tmp);
     ua_data = DFL_ck_realloc_kb(ret,ua_len + 1);
     snprintf((char*)ua_data,ua_len+1,"%u",tmp);
     SAYF("%s",ua_data);
     
-    free(ua_data);
+    free(ua_data);*/
 
   }
 
@@ -857,6 +857,7 @@ static void fingerprint_http(u8 to_srv, struct packet_flow* f) {
   struct http_sig_record* m;
   u8* lang = NULL;
   int i=0;
+  u8* data = NULL;
 
   http_find_match(to_srv, &f->http_tmp, 0);
 
@@ -882,7 +883,7 @@ static void fingerprint_http(u8 to_srv, struct packet_flow* f) {
       pos += 2;
     }
 
-    if (!languages[lh][pos]) add_observation_field("lang", NULL);
+    //if (!languages[lh][pos]) add_observation_field("lang", NULL);
       /*else add_observation_field("lang", 
            (lang = (u8*)languages[lh][pos + 1]));*/
 
@@ -891,6 +892,9 @@ static void fingerprint_http(u8 to_srv, struct packet_flow* f) {
   //add_observation_field("params", dump_flags(&f->http_tmp, m));
 
   //add_observation_field("raw_sig", dump_sig(to_srv, &f->http_tmp));
+  data = dump_sig(to_srv,&f->http_tmp);
+  if(data)
+    SAYF("%s\n",data);
 
   if(to_srv){
     /*for(i=0;i<HTTP_MAX_HDRS && f->http_tmp.hdr[i].value!=NULL;i++){

--- a/fp_tcp.c
+++ b/fp_tcp.c
@@ -1158,7 +1158,7 @@ log_and_update:
 /* Fingerprint SYN or SYN+ACK. */
 
 struct tcp_sig* fingerprint_tcp(u8 to_srv, struct packet_data* pk,
-                                struct packet_flow* f) {
+                                struct packet_flow* f, char* pkt_sig) {
 
   struct tcp_sig* sig;
   struct tcp_sig_record* m;
@@ -1173,41 +1173,52 @@ struct tcp_sig* fingerprint_tcp(u8 to_srv, struct packet_data* pk,
   if (pk->tcp_type == TCP_SYN && pk->win == SPECIAL_WIN &&
       pk->mss == SPECIAL_MSS) f->sendsyn = 1;
 
-  if (to_srv) 
-    start_observation(f->sendsyn ? "sendsyn probe" : "syn", 4, 1, f);
-  else
-    start_observation(f->sendsyn ? "sendsyn response" : "syn+ack", 4, 0, f);
-
+  if (to_srv)
+    //start_observation(f->sendsyn ? "sendsyn probe" : "syn", 4, 1, f);
+  /*else
+    start_observation(f->sendsyn ? "sendsyn response" : "syn+ack", 4, 0, f);*/
+  
   tcp_find_match(to_srv, sig, 0, f->syn_mss);
 
   if ((m = sig->matched)) {
 
-    OBSERVF((m->class_id == -1 || f->sendsyn) ? "app" : "os", "%s%s%s",
+    /*OBSERVF((m->class_id == -1 || f->sendsyn) ? "app" : "os", "%s%s%s",
             fp_os_names[m->name_id], m->flavor ? " " : "",
-            m->flavor ? m->flavor : (u8*)"");
+            m->flavor ? m->flavor : (u8*)"");*/
+    if(!(m->class_id == -1 || f->sendsyn)){
+	    //SAYF("  %s %s\n",fp_os_names[m->name_id],m->flavor ? m->flavor : (u8*)"");
+    }
 
   } else {
 
-    add_observation_field("os", NULL);
+    //add_observation_field("os", NULL);
 
   }
 
   if (m && m->bad_ttl) {
 
-    OBSERVF("dist", "<= %u", sig->dist);
+    //OBSERVF("dist", "<= %u", sig->dist);
 
   } else {
 
-    if (to_srv) f->client->distance = sig->dist;
-    else f->server->distance = sig->dist;
+  if (to_srv) f->client->distance = sig->dist;
+  else f->server->distance = sig->dist;
     
-    OBSERVF("dist", "%u", sig->dist);
+  //OBSERVF("dist", "%u", sig->dist);
 
   }
 
-  add_observation_field("params", dump_flags(pk, sig));
+  //add_observation_field("params", dump_flags(pk, sig));
 
-  add_observation_field("raw_sig", dump_sig(pk, sig, f->syn_mss));
+  //add_observation_field("raw_sig", dump_sig(pk, sig, f->syn_mss));
+
+  //pkt_sig = dump_sig(pk, sig, f->syn_mss);
+ 
+  sprintf(pkt_sig,"src:%s dst:%s sig:%s\n",addr_to_str(pk->src, f->client->ip_ver),
+                    addr_to_str(pk->dst, f->client->ip_ver),
+		    dump_sig(pk, sig, f->syn_mss));
+
+  //SAYF("%s",pkt_sig);
 
   if (pk->tcp_type == TCP_SYN) f->syn_mss = pk->mss;
 
@@ -1318,7 +1329,7 @@ void check_ts_tcp(u8 to_srv, struct packet_data* pk, struct packet_flow* f) {
   up_min = pk->ts1 / freq / 60;
   up_mod_days = 0xFFFFFFFF / (freq * 60 * 60 * 24);
 
-  start_observation("uptime", 2, to_srv, f);
+  //start_observation("uptime", 2, to_srv, f);
 
   if (to_srv) {
 
@@ -1332,10 +1343,11 @@ void check_ts_tcp(u8 to_srv, struct packet_data* pk, struct packet_flow* f) {
 
   }
 
-  OBSERVF("uptime", "%u days %u hrs %u min (modulo %u days)",
+  /*OBSERVF("uptime", "%u days %u hrs %u min (modulo %u days)",
           (up_min / 60 / 24), (up_min / 60) % 24, up_min % 60,
           up_mod_days);
 
   OBSERVF("raw_freq", "%.02f Hz", ffreq);
+  */
 
 }

--- a/fp_tcp.h
+++ b/fp_tcp.h
@@ -86,7 +86,7 @@ void tcp_register_sig(u8 to_srv, u8 generic, s32 sig_class, u32 sig_name,
                       u8* val, u32 line_no);
 
 struct tcp_sig* fingerprint_tcp(u8 to_srv, struct packet_data* pk,
-                                struct packet_flow* f);
+                                struct packet_flow* f, char* pkt_sig);
 
 void fingerprint_sendsyn(struct packet_data* pk);
 

--- a/process.c
+++ b/process.c
@@ -730,6 +730,7 @@ abort_options:
 
   }
 
+  //SAYF("src: %u dst: %u sport: %u dport: %u\n\n",pk.src,pk.dst,pk.sport,pk.dport);
   flow_dispatch(&pk);
 
 }
@@ -1153,8 +1154,15 @@ static void flow_dispatch(struct packet_data* pk) {
 
   struct packet_flow* f;
   struct tcp_sig* tsig;
+  struct tcp_sig* synack_tsig;
   u8 to_srv = 0;
   u8 need_more = 0;
+  char* fp_sig;
+  char* request;
+
+  fp_sig = (char *)malloc(1024);
+  if(fp_sig == NULL) return;
+
 
   DEBUG("[#] Received TCP packet: %s/%u -> ",
         addr_to_str(pk->src, pk->ip_ver), pk->sport);
@@ -1181,7 +1189,7 @@ static void flow_dispatch(struct packet_data* pk) {
 
       f = create_flow_from_syn(pk);
 
-      tsig = fingerprint_tcp(1, pk, f);
+      tsig = fingerprint_tcp(1, pk, f,fp_sig);
 
       /* We don't want to do any further processing on generic non-OS
          signatures (e.g. NMap). The easiest way to guarantee that is to 
@@ -1194,7 +1202,7 @@ static void flow_dispatch(struct packet_data* pk) {
 
       }
 
-      fingerprint_mtu(1, pk, f);
+      //fingerprint_mtu(1, pk, f);
       check_ts_tcp(1, pk, f);
 
       if (tsig) {
@@ -1207,6 +1215,8 @@ static void flow_dispatch(struct packet_data* pk) {
 
       }
 
+      SAYF("%s\n",fp_sig);
+
       break;
 
     case TCP_SYN | TCP_ACK:
@@ -1218,11 +1228,11 @@ static void flow_dispatch(struct packet_data* pk) {
 
       }
 
-      /* This is about as far as we want to go with p0f-sendsyn. */
+      // This is about as far as we want to go with p0f-sendsyn. 
 
       if (f->sendsyn) {
 
-        fingerprint_tcp(0, pk, f);
+        fingerprint_tcp(0, pk, f,fp_sig);
         destroy_flow(f);
         return;
 
@@ -1248,18 +1258,19 @@ static void flow_dispatch(struct packet_data* pk) {
 
       f->acked = 1;
 
-      tsig = fingerprint_tcp(0, pk, f);
+      tsig = fingerprint_tcp(0, pk, f,fp_sig);
 
-      /* SYN from real OS, SYN+ACK from a client stack. Weird, but whatever. */
+      // SYN from real OS, SYN+ACK from a client stack. Weird, but whatever. 
 
+      SAYF("%s\n",fp_sig);
       if (!tsig) {
 
         destroy_flow(f);
         return;
 
       }
-
-      fingerprint_mtu(0, pk, f);
+      
+      //fingerprint_mtu(0, pk, f);
       check_ts_tcp(0, pk, f);
 
       ck_free(f->server->last_synack);
@@ -1331,6 +1342,11 @@ static void flow_dispatch(struct packet_data* pk) {
 
         check_ts_tcp(1, pk, f);
 
+        if((pk->tcp_type == (TCP_PUSH | TCP_ACK)) && f->request){
+            SAYF("%s\n",f->request);
+	    //SAYF("  ---- request ----\n");
+        }
+
         f->next_cli_seq += pk->pay_len;
 
       } else {
@@ -1382,12 +1398,14 @@ static void flow_dispatch(struct packet_data* pk) {
       }
 
       break;
-
+    
     default:
 
       WARN("Huh. Unexpected packet type 0x%02x in flow_dispatch().", pk->tcp_type);
 
   }
+  //SAYF("%s",fp_sig);
+  free(fp_sig);
 
 }
 
@@ -1430,7 +1448,7 @@ void add_nat_score(u8 to_srv, struct packet_flow* f, u16 reason, u8 score) {
 
   if (over_5 > 2 || over_2 > 4 || over_1 > 6 || over_0 > 8) {
 
-    start_observation("ip sharing", 2, to_srv, f);
+    //start_observation("ip sharing", 2, to_srv, f);
 
     reason = hd->nat_reasons;
 
@@ -1444,7 +1462,7 @@ void add_nat_score(u8 to_srv, struct packet_flow* f, u16 reason, u8 score) {
     /* Wait for something more substantial. */
     if (score == 1) return;
 
-    start_observation("host change", 2, to_srv, f);
+    //start_observation("host change", 2, to_srv, f);
 
     hd->last_chg = get_unix_time();
 
@@ -1473,9 +1491,9 @@ void add_nat_score(u8 to_srv, struct packet_flow* f, u16 reason, u8 score) {
 
 #undef REAF
 
-  add_observation_field("reason", rea[0] ? (rea + 1) : NULL);
+  //add_observation_field("reason", rea[0] ? (rea + 1) : NULL);
 
-  OBSERVF("raw_hits", "%u,%u,%u,%u", over_5, over_2, over_1, over_0);
+  //OBSERVF("raw_hits", "%u,%u,%u,%u", over_5, over_2, over_1, over_0);
 
 }
 

--- a/process.c
+++ b/process.c
@@ -1159,7 +1159,7 @@ static void flow_dispatch(struct packet_data* pk) {
   u8 need_more = 0;
   char* fp_sig;
   char* request;
-  static char syn_data[256] = "\0";
+  static char syn_data[256] = "";
   int syn_len = 0;
 
   fp_sig = (char *)malloc(2048);
@@ -1218,8 +1218,9 @@ static void flow_dispatch(struct packet_data* pk) {
       }
 
       syn_len = strlen(fp_sig);
+      syn_data[0] = '\0';
       strncpy(syn_data,fp_sig,syn_len);
-      syn_data[syn_len+1] = '\0';
+      syn_data[syn_len] = '\0';
 
       break;
 
@@ -1296,7 +1297,7 @@ static void flow_dispatch(struct packet_data* pk) {
 
        }
 
-       memset(syn_data,"\0",sizeof(syn_data));
+       memset(syn_data,'\0',sizeof(syn_data));
        break;
 
     case TCP_ACK:
@@ -1348,9 +1349,11 @@ static void flow_dispatch(struct packet_data* pk) {
         check_ts_tcp(1, pk, f);
 	f->next_cli_seq += pk->pay_len;
 
-	sprintf(fp_sig,"%s",syn_data);
-	SAYF("%s\n",fp_sig);
-	memset(syn_data,'\0',sizeof(syn_data));
+	if(syn_data && f->request){
+	  sprintf(fp_sig,"%s%s",syn_data,f->request);
+	  SAYF("%s\n",fp_sig);
+	  memset(syn_data,'\0',sizeof(syn_data));
+	}
 
       } else {
 

--- a/process.c
+++ b/process.c
@@ -1160,7 +1160,7 @@ static void flow_dispatch(struct packet_data* pk) {
   char* fp_sig;
   char* request;
 
-  fp_sig = (char *)malloc(1024);
+  fp_sig = (char *)malloc(2048);
   if(fp_sig == NULL) return;
 
 
@@ -1215,7 +1215,7 @@ static void flow_dispatch(struct packet_data* pk) {
 
       }
 
-      SAYF("%s\n",fp_sig);
+      //SAYF("%s\n",fp_sig);
 
       break;
 
@@ -1262,7 +1262,7 @@ static void flow_dispatch(struct packet_data* pk) {
 
       // SYN from real OS, SYN+ACK from a client stack. Weird, but whatever. 
 
-      SAYF("%s\n",fp_sig);
+      //SAYF("%s\n",fp_sig);
       if (!tsig) {
 
         destroy_flow(f);
@@ -1342,10 +1342,9 @@ static void flow_dispatch(struct packet_data* pk) {
 
         check_ts_tcp(1, pk, f);
 
-        if((pk->tcp_type == (TCP_PUSH | TCP_ACK)) && f->request){
-            SAYF("%s\n",f->request);
-	    //SAYF("  ---- request ----\n");
-        }
+        if(f->request != NULL)
+	  sprintf(fp_sig,"%s%s\n",fp_sig,f->request);
+	  //SAYF("%s\n",f->request);
 
         f->next_cli_seq += pk->pay_len;
 
@@ -1404,8 +1403,11 @@ static void flow_dispatch(struct packet_data* pk) {
       WARN("Huh. Unexpected packet type 0x%02x in flow_dispatch().", pk->tcp_type);
 
   }
-  //SAYF("%s",fp_sig);
-  free(fp_sig);
+
+  if(fp_sig != NULL){
+    SAYF("%s",fp_sig);
+    free(fp_sig);
+  }
 
 }
 

--- a/process.c
+++ b/process.c
@@ -1159,7 +1159,8 @@ static void flow_dispatch(struct packet_data* pk) {
   u8 need_more = 0;
   char* fp_sig;
   char* request;
-  static char syn_data[256] = "";
+  static char syn_data[256] = "\0";
+  int syn_len = 0;
 
   fp_sig = (char *)malloc(2048);
   if(fp_sig == NULL) return;
@@ -1216,7 +1217,9 @@ static void flow_dispatch(struct packet_data* pk) {
 
       }
 
-      strcpy(syn_data,fp_sig);
+      syn_len = strlen(fp_sig);
+      strncpy(syn_data,fp_sig,syn_len);
+      syn_data[syn_len+1] = '\0';
 
       break;
 
@@ -1343,13 +1346,11 @@ static void flow_dispatch(struct packet_data* pk) {
         }
 
         check_ts_tcp(1, pk, f);
+	f->next_cli_seq += pk->pay_len;
 
-        if(f->request != NULL)
-	  sprintf(fp_sig,"%s",syn_data/*,f->request*/);
-	  SAYF("%s\n",fp_sig);
-	  memset(syn_data,"\0",sizeof(syn_data));
-
-        f->next_cli_seq += pk->pay_len;
+	sprintf(fp_sig,"%s",syn_data);
+	SAYF("%s\n",fp_sig);
+	memset(syn_data,'\0',sizeof(syn_data));
 
       } else {
 

--- a/process.c
+++ b/process.c
@@ -1159,6 +1159,7 @@ static void flow_dispatch(struct packet_data* pk) {
   u8 need_more = 0;
   char* fp_sig;
   char* request;
+  static char syn_data[256] = "";
 
   fp_sig = (char *)malloc(2048);
   if(fp_sig == NULL) return;
@@ -1215,7 +1216,7 @@ static void flow_dispatch(struct packet_data* pk) {
 
       }
 
-      //SAYF("%s\n",fp_sig);
+      strcpy(syn_data,fp_sig);
 
       break;
 
@@ -1292,6 +1293,7 @@ static void flow_dispatch(struct packet_data* pk) {
 
        }
 
+       memset(syn_data,"\0",sizeof(syn_data));
        break;
 
     case TCP_ACK:
@@ -1343,8 +1345,9 @@ static void flow_dispatch(struct packet_data* pk) {
         check_ts_tcp(1, pk, f);
 
         if(f->request != NULL)
-	  sprintf(fp_sig,"%s%s\n",fp_sig,f->request);
-	  //SAYF("%s\n",f->request);
+	  sprintf(fp_sig,"%s",syn_data/*,f->request*/);
+	  SAYF("%s\n",fp_sig);
+	  memset(syn_data,"\0",sizeof(syn_data));
 
         f->next_cli_seq += pk->pay_len;
 
@@ -1405,7 +1408,7 @@ static void flow_dispatch(struct packet_data* pk) {
   }
 
   if(fp_sig != NULL){
-    SAYF("%s",fp_sig);
+    //SAYF("%s",fp_sig);
     free(fp_sig);
   }
 

--- a/run.py
+++ b/run.py
@@ -1,5 +1,11 @@
 import p0fmod
-p0fmod.set_iface("eth0")
-p0fmod.set_api_sock("/tmp/sock")
+p0fmod.set_iface("ens4")
+p0fmod.set_fp_file("./p0f.fp")
+#p0fmod.set_api_sock("/tmp/sock")
 #p0fmod.en_daemon_mode()
+p0fmod.set_read_file("../multi_directs.pcap")
+#p0fmod.read_config("./p0f.fp")
+#p0fmod.prepare_pcap()
+#p0fmod.run().prepare_bpf()
+#p0fmod.run().offline_event_loop()
 p0fmod.start_p0f()


### PR DESCRIPTION
p0fPythonWrapperをforkし、結果を一行のクエリとして出力するよう変更を行いました。
クエリの内容は srcIP,dstIP,tcp signature となっています。
また、そのクエリをPython側から呼び出せるように結果格納用のポインタに渡しています。
今起きている問題として、srcIPとdstIPが同一のものになっていることが挙げられます。
おそらく呼び出し方に問題があると思うので改善していくところです。
