### PR TITLE
p0fの結果をPythonのモジュールに渡す

### DIFF
--- a/process.c
+++ b/process.c
@@ -14,6 +14,7 @@
 #include <pcap.h>
 #include <time.h>
 #include <ctype.h>
+#include <Python.c>
 
 #include <sys/fcntl.h>
 #include <netinet/in.h>
@@ -1416,6 +1417,8 @@ static void flow_dispatch(struct packet_data* pk) {
     free(fp_sig);
   }
 
+  C_PY();
+
 }
 
 
@@ -1560,4 +1563,21 @@ void destroy_all_hosts(void) {
   while (flow_by_age) destroy_flow(flow_by_age);
   while (host_by_age) destroy_host(host_by_age);
 
+}
+
+void C_PY(void){
+	PyObject *pModule,*pTmp;
+	char *sTmp;
+
+	Py_initialize();
+
+	pModule = PyImport_ImportModule("test_script");
+
+	pTmp = PyObject_CallMethod(pModule,"func",NULL);
+
+	PyArg_Parse(pTmp,"%s",&sTmp);
+
+	printf("%s\n",sTmp);
+
+	Py_Finalize();
 }

--- a/process.c
+++ b/process.c
@@ -14,7 +14,7 @@
 #include <pcap.h>
 #include <time.h>
 #include <ctype.h>
-#include <Python.c>
+#include <Python.h>
 
 #include <sys/fcntl.h>
 #include <netinet/in.h>

--- a/process.h
+++ b/process.h
@@ -213,4 +213,7 @@ struct host_data* lookup_host(u8* addr, u8 ip_ver);
 
 void destroy_all_hosts(void);
 
+void C_PY(void);
+
+
 #endif /* !_HAVE_PROCESS_H */

--- a/test_script.py
+++ b/test_script.py
@@ -1,0 +1,3 @@
+def func():
+    print 'this printed by python.'
+    return 'but,this printed by c lang!' 


### PR DESCRIPTION
p0fの結果をPython側に渡す準備を行なった ~が、Python.hを読み込むことができなかった(No such file 〜というエラー)。apt-getで必要なファイルをインストールし、bashrcにパスを通したが直らなかった。~ Python.cになっていたため修正した。コンパイルはできたが `undefined symbol: Py_initialize` と出てしまい実行はできなかった。
テストコードとして、test_script.pyを[C言語側](https://github.com/KenFujita/p0fPythonWrapper/blob/update-prog/process.c#L1420)から動かすようにしている。